### PR TITLE
Add rudimentary check to prevent error when handling clicks on empty tiles

### DIFF
--- a/tile_map_controller.gd
+++ b/tile_map_controller.gd
@@ -12,7 +12,8 @@ func _input(event):
 			print(pos_clicked)
 			var current_atlas_coords = get_cell_atlas_coords(main_layer, pos_clicked)
 			var current_tile_alt = get_cell_alternative_tile(main_layer, pos_clicked)
-			var number_of_alts_for_clicked = tile_set.get_source(main_atlas_id)\
-								.get_alternative_tiles_count(current_atlas_coords)
-			set_cell(main_layer, pos_clicked, main_atlas_id, current_atlas_coords, 
-							(current_tile_alt + 1) %  number_of_alts_for_clicked)
+			if current_tile_alt > -1:
+				var number_of_alts_for_clicked = tile_set.get_source(main_atlas_id)\
+						.get_alternative_tiles_count(current_atlas_coords)
+				set_cell(main_layer, pos_clicked, main_atlas_id, current_atlas_coords, 
+						(current_tile_alt + 1) %  number_of_alts_for_clicked)


### PR DESCRIPTION
The project "silently" throws the following error when run if the user clicks outside of the existing tiles:

```
E 0:00:02:0601   tile_map_controller.gd:15 @ _input(): The TileSetAtlasSource atlas has no tile at (-1, -1).
  <C++ Error>    Condition "!tiles.has(p_atlas_coords)" is true. Returning: -1
  <C++ Source>   scene/resources/tile_set.cpp:4528 @ get_alternative_tiles_count()
  <Stack Trace>  tile_map_controller.gd:15 @ _input()
```
("silently" because there is nothing shown in run "Output", only in the debugger's "Errors" tab).

This pull request introduces the simplest possible handling of such a case to avoid raising an error.

`get_cell_alternative_tile()` returns `-1` when called on an empty tile, and valid alternative tile ids appear to always be 0 or greater. Furthermore, the behavior achieved by the following code (toggling between alternatives for the tile clicked) has no meaning on an empty / unset tile. So we can simply skip these lines of code when the user clicks on an empty tile.

Given that this is in the Godot Asset Library as a tutorial / example, a user exploring it for the first time might not be sufficiently familiar with TileMaps to recognize the currently occurring error as "normal" or intended (or at the very least, inconsequential to the demo).

The point of this pull request is to prevent users thinking this asset is "broken". If the project owner prefers not to introduce error handling or edge cases to keep the overall demo simple, perhaps a comment next to the expression `.get_alternative_tiles_count(current_atlas_coords)` could be added to warn the user that they will need to consider this case when using this demo for inspiration for their own projects.